### PR TITLE
Fix/2 rivers run next to eachother

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    // ... other Jest configuration options
+};

--- a/package.json
+++ b/package.json
@@ -16,14 +16,17 @@
     "@babel/core": "^7.21.8",
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.21.5",
+    "@babel/preset-typescript": "^7.22.5",
+    "@jest/globals": "^29.6.2",
+    "@types/jest": "^29.5.3",
     "babel-loader": "^9.1.2",
     "core-js": "^3.30.2",
-    "ts-jest": "^29.1.0",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.4",
     "webpack": "^5.82.1",
     "webpack-cli": "^5.1.1",
     "webpack-dev-server": "^4.15.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/src/point.ts
+++ b/src/point.ts
@@ -4,7 +4,7 @@ export const pointsEqual = (a: point, b: point) => {
   return a.x == b.x && a.y == b.y;
 };
 
-export type parentedPoint = { point: point; parent: parentedPoint | undefined };
+export type parentedPoint = { point: point; parent: parentedPoint | undefined , distance: number};
 
 export function addPoints(a: point, b: point): point {
   return { x: a.x + b.x, y: a.y + b.y };

--- a/src/river.test.ts
+++ b/src/river.test.ts
@@ -1,0 +1,31 @@
+import {insertInSortedQueue, squaredDistanceBetweenPoints} from "./river";
+import {parentedPoint} from "./point";
+
+describe('helper function river path', () => {
+    test("distance calculation easy", () => {
+        const pointA = {x: 0, y: 0};
+        const pointB = {x: 0, y: 10};
+        expect(squaredDistanceBetweenPoints(pointA, pointB)).toBe(10 * 10);
+    })
+
+    test("distance calculation easy", () => {
+        const pointA = {x: 10, y: 10};
+        const pointB = {x: 20, y: 20};
+        expect(squaredDistanceBetweenPoints(pointA, pointB)).toBe(10 * 10 + 10*10);
+    })
+
+    test("sorted queue", () => {
+        const pointA = {point: {x: 0, y: 0}, parent: undefined, distance: 0};
+        const pointB = {point: {x: 0, y: 0}, parent: undefined, distance: 50};
+        const pointC = {point: {x: 0, y: 0}, parent: undefined, distance: 100};
+
+        const queue: parentedPoint[] = [];
+        insertInSortedQueue(queue, pointC);
+        expect(queue).toEqual([pointC]);
+        insertInSortedQueue(queue, pointA);
+        expect(queue).toEqual([pointA, pointC]);
+        insertInSortedQueue(queue, pointB);
+        expect(queue).toEqual([pointA, pointB, pointC]);
+    })
+
+});

--- a/src/river.ts
+++ b/src/river.ts
@@ -5,9 +5,6 @@ import {
   parentedPoint,
   getNeighbourPoints,
   parentedToList,
-  pointInsideMap,
-  pointsEqual,
-  withZ,
 } from "./point";
 import { getZ, isWater, markPos } from "./terrain";
 
@@ -16,9 +13,9 @@ import { getZ, isWater, markPos } from "./terrain";
  * @param pos
  */
 export const pathRiverFrom = (pos: point, rivers: SeenSet): point[] => {
-  var path: parentedPoint[] = [{ point: pos, parent: undefined }];
-  var i = 0;
-  var current = pos;
+  const path: parentedPoint[] = [{ point: pos, parent: undefined, distance: 0 }];
+  let i = 0;
+  let current = pos;
   let waterReached = false;
   while (i < 1000) {
     i++;
@@ -48,21 +45,36 @@ export const pathRiverFrom = (pos: point, rivers: SeenSet): point[] => {
   return path.map((a) => a.point);
 };
 
+
+export const squaredDistanceBetweenPoints = (a: point, b: point) => {
+    const diff = {x: a.x-b.x, y: a.y-b.y};
+    return diff.x*diff.x + diff.y*diff.y;
+}
+
+export const insertInSortedQueue = (sortedQueue: parentedPoint[], point: parentedPoint): void => {
+    let i = 0;
+    for (let iteratorPoint of sortedQueue) {
+          if (iteratorPoint.distance > point.distance) break;
+          i++;
+    }
+    sortedQueue.splice(i, 0, point);
+}
+
 /**
  * find the point closest to pos thats at least one block lower
  * @param pos
  * @param posZ
  * @returns path to this point from pos where pos is the first entry, drop the last
  */
-function findClosestDrop(
+export function findClosestDrop(
   pos: point,
   posZ: number,
 ): parentedPoint[] {
-  var seenSet: SeenSet = makeSet();
+  const seenSet: SeenSet = makeSet();
 
-  var queue: parentedPoint[] = [{ point: pos, parent: undefined }];
+  const queue: parentedPoint[] = [{ point: pos, parent: undefined, distance: 0 }];
   let next: parentedPoint;
-  var safetyIterator = 0;
+  let safetyIterator = 0;
   seenSet.add(pos);
   while (queue.length != 0 && safetyIterator < 10000) {
     next = queue.shift() as parentedPoint;
@@ -90,7 +102,7 @@ function findClosestDrop(
       if (lower) {
         //unknown point
         seenSet.add(n);
-        queue.push({ point: n, parent: next });
+        insertInSortedQueue(queue, { point: n, parent: next, distance: squaredDistanceBetweenPoints(n, pos) });
       } else {
       }
     });

--- a/src/river.ts
+++ b/src/river.ts
@@ -22,7 +22,7 @@ export const pathRiverFrom = (pos: point, rivers: SeenSet): point[] => {
   let waterReached = false;
   while (i < 1000) {
     i++;
-    const pathToDrop = findClosestDrop(current, getZ(current), false);
+    const pathToDrop = findClosestDrop(current, getZ(current));
     if (pathToDrop.length == 0)
       //abort if closestDrop coulndt find anything
       break;
@@ -57,7 +57,6 @@ export const pathRiverFrom = (pos: point, rivers: SeenSet): point[] => {
 function findClosestDrop(
   pos: point,
   posZ: number,
-  floor: boolean
 ): parentedPoint[] {
   var seenSet: SeenSet = makeSet();
 
@@ -69,16 +68,15 @@ function findClosestDrop(
     next = queue.shift() as parentedPoint;
 
     //abort condition
-    if (getZ(next.point, floor) < posZ) {
+    if (getZ(next.point, true) < Math.round(posZ)) {
       const path = parentedToList(next, []).reverse();
       return path;
     }
 
-    var neighbours = getNeighbourPoints(next.point);
+    const neighbours = getNeighbourPoints(next.point).filter(seenSet.hasNot);
     neighbours.forEach(function (n) {
-      const lower = getZ(n, floor) <= posZ;
-      const unseen = !seenSet.has(n);
-      if (lower && unseen) {
+      const lower = getZ(n, false) <= posZ;
+      if (lower) {
         //unknown point
         seenSet.add(n);
         queue.push({ point: n, parent: next });
@@ -86,10 +84,6 @@ function findClosestDrop(
       }
     });
     safetyIterator++;
-  }
-  if (!floor) {
-    //try again with rounded numbers
-    return findClosestDrop(pos, Math.round(posZ), true);
   }
   return [];
 }

--- a/src/river.ts
+++ b/src/river.ts
@@ -94,7 +94,7 @@ export function findClosestDrop(
             const bZ = getZ(b, false);
             return aZ-bZ;
         });
-        markPos(next.point, 3)
+     //   markPos(next.point, 3)
     }
 
     neighbours.forEach(function (n) {

--- a/src/river.ts
+++ b/src/river.ts
@@ -73,7 +73,18 @@ function findClosestDrop(
       return path;
     }
 
-    const neighbours = getNeighbourPoints(next.point).filter(seenSet.hasNot);
+    let neighbours = getNeighbourPoints(next.point).filter(seenSet.hasNot);
+    const trueLowerNeighbours = neighbours.filter(n => getZ(n, true) < Math.round(posZ));
+    if (trueLowerNeighbours.length == 0) {
+        //no lower neighbour, river is in flat area => sort by tinyest height difference
+        neighbours = neighbours.sort((a, b) => {
+            const aZ = getZ(a, false);
+            const bZ = getZ(b, false);
+            return aZ-bZ;
+        });
+        markPos(next.point, 3)
+    }
+
     neighbours.forEach(function (n) {
       const lower = getZ(n, false) <= posZ;
       if (lower) {


### PR DESCRIPTION
Ensures that rivers try to merge if they can, avoids parallel, touching streams
Improves meandering quite a lot. Searching for droppos now takes into account distance from start.
The searching now is circular instead of diamond shaped.

![grafik](https://github.com/IR0NSIGHT/Puddler/assets/32139214/41b7b128-609d-4bd4-97c7-49c9b9bba702)
