### PR TITLE
fix: correct 'Ocean Water Leve' → 'Ocean Water Level' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ https://youtu.be/kUJXZ7FjP7Y
 - Flood Puddles: Puddles (Lakes) will be filled with water
 - Apply Rivers: Rivers will be filled with water
 - Apply as Annotations: Rivers and Puddles will be annotated in Orange and Purple
-- Ocean Water Leve: Rivers will stop once they reach this height. Should match your ocean level.
+- Ocean Water Level: Rivers will stop once they reach this height. Should match your ocean level.


### PR DESCRIPTION
## Summary
Fixes typo in README.md: 'Ocean Water Leve' → 'Ocean Water Level'

## Issue
https://github.com/IR0NSIGHT/Puddler/issues/22

## Changes
- README.md line 41: corrected 'Ocean Water Leve' to 'Ocean Water Level'

## Verification
```
grep -n 'Ocean Water' README.md
41:- Ocean Water Level: Rivers will stop once they reach this height. Should match your ocean level.
```